### PR TITLE
Lower crypto constraints

### DIFF
--- a/src/erequest_id.erl
+++ b/src/erequest_id.erl
@@ -12,7 +12,7 @@
                     {ok, RequestId} when
       RequestId :: request_id().
 create() ->
-    UuidV4 = uuid:get_v4(),
+    UuidV4 = uuid:get_v4(weak),
     UuidV4Bin = uuid:uuid_to_string(UuidV4, binary_standard),
     {ok, UuidV4Bin}.
 


### PR DESCRIPTION
For frequent calls, strong_crypto may yield slow results and end up
blocking when entropy goes down. using 'weak' crypto still goes through
the crypto module's random functions, but uses a weaker PRNG that is
still auto-seeded and better than random:uniform/1-2, but likely allows
for more throughput and performance predictability.
